### PR TITLE
add negative potion costs + crit damage on items

### DIFF
--- a/client/src/desktop/components/AdventurerStats.tsx
+++ b/client/src/desktop/components/AdventurerStats.tsx
@@ -105,7 +105,7 @@ export default function AdventurerStats() {
     } else if (stat === 'charisma') {
       return (
         <Box>
-          <Typography sx={styles.tooltipValue}>Potion cost: {potionPrice(level, currentValue)} Gold</Typography>
+          <Typography sx={styles.tooltipValue}>Potion cost: {potionPrice(level, currentValue)} Gold (current {potionPrice(level, currentValue, true)})</Typography>
           <Typography sx={styles.tooltipValue}>Item discount: {currentValue} Gold</Typography>
         </Box>
       );

--- a/client/src/desktop/components/ItemTooltip.tsx
+++ b/client/src/desktop/components/ItemTooltip.tsx
@@ -26,6 +26,7 @@ export default function ItemTooltip({ itemSpecialsSeed, item, style }: ItemToolt
   // Calculate damage if there's a beast and this is an armor or weapon item
   let damage = null;
   let damageTaken = null;
+  let damageTakenCritical = null;
   let isNameMatch = false;
 
   if (beast) {
@@ -33,6 +34,7 @@ export default function ItemTooltip({ itemSpecialsSeed, item, style }: ItemToolt
 
     if (['Head', 'Chest', 'Foot', 'Hand', 'Waist'].includes(ItemUtils.getItemSlot(item.id))) {
       damageTaken = calculateBeastDamage(beast, adventurer!, item);
+      damageTakenCritical = calculateBeastDamage(beast, adventurer!, item, true);
     } else if (ItemUtils.isWeapon(item.id)) {
       damage = calculateAttackDamage(item, adventurer!, beast);
     }
@@ -101,6 +103,8 @@ export default function ItemTooltip({ itemSpecialsSeed, item, style }: ItemToolt
                 </Box>
               )}
               {damageTaken && `-${damageTaken} health when hit`}
+              <br/>
+              {damageTakenCritical && `-${damageTakenCritical} (${calculateLevel(adventurer?.xp || 0)}% critical hit chance)`}
             </Typography>
           </Box>
         </>

--- a/client/src/desktop/overlays/Market.tsx
+++ b/client/src/desktop/overlays/Market.tsx
@@ -352,13 +352,25 @@ export default function MarketOverlay() {
                       <Box sx={styles.potionControls}>
                         <Typography sx={styles.potionCost}>Cost: {potionCost} Gold</Typography>
                       </Box>
-                      <Slider
-                        value={cart.potions}
-                        onChange={(_, value) => handleBuyPotion(value as number)}
-                        min={0}
-                        max={maxPotions}
-                        sx={styles.potionSlider}
-                      />
+                        <Slider
+                          value={cart.potions}
+                          onChange={(_, value) => handleBuyPotion(value as number)}
+                          min={0}
+                          max={maxPotions}
+                          sx={styles.potionSlider}
+                        />
+
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <Typography sx={styles.potionHelperText}>Current cost: {potionPrice(calculateLevel(adventurer?.xp || 0), adventurer?.stats?.charisma || 0, true)}</Typography>
+                          <Button
+                            variant="contained"
+                            color="inherit" 
+                            disabled={inProgress || remainingGold < 0}
+                            onClick={() => handleBuyPotion(maxPotions)}
+                            >
+                          <Typography sx={styles.potionHelperText}>Max</Typography> 
+                          </Button>
+                        </Box>
                     </Box>
                   </Box>
                 </Box>

--- a/client/src/utils/market.ts
+++ b/client/src/utils/market.ts
@@ -34,6 +34,10 @@ export function generateMarketItems(marketItemIds: number[], charisma: number): 
   return items;
 }
 
-export function potionPrice(level: number, charisma: number): number {
-  return Math.max(1, level - (charisma * 2));
+export function potionPrice(level: number, charisma: number, negative: boolean = false): number {
+  const price = level - (charisma * 2);
+  if (negative) {
+    return price;
+  }
+  return Math.max(1, price);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Item tooltips now display critical damage taken and your level-based critical hit chance for armor when facing beasts.
  - Market overlay shows the current health potion cost and adds a Max button to quickly set potions to the maximum allowed.
  - Charisma tooltip now includes the current potion price alongside the base price.

- Style
  - Minor layout and spacing tweaks around the potion controls to accommodate the new cost readout and Max button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->