### PR TITLE
ci: run Claude Code workflow on Fable 5

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,8 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Use Claude Fable 5, Anthropic's most capable model, for all reviews
+          model: "claude-fable-5"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## Summary
- Set `model: "claude-fable-5"` on the `anthropics/claude-code-action` step in `.github/workflows/claude.yml`, so `@claude` mentions on issues and PRs are handled by Claude Fable 5 (Anthropic's most capable model) instead of the action's default (Opus 4.8).
- Replaced the stale commented-out example (`claude-opus-4-20250514`, a deprecated model ID) with the explicit model setting.

## Notes
- Fable 5 is priced at $10/$50 per MTok (input/output) vs Opus 4.8's $5/$25 — the increased API cost is expected and accepted.
- No other workflow behavior changes (triggers, permissions, and auth via `CLAUDE_CODE_OAUTH_TOKEN` are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->